### PR TITLE
Update API URL, add natsort, and bump version to 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
 ---
 
+> **⚠️ Important Notice - URL Update**: The CyteType API URL has been updated. If you have bookmarked or saved any old report links, please update them to use the new domain. The new API endpoint is now active at `https://cytetype.nygen.io`.
+
 **CyteType** is a Python package for deep chracterization of cell clusters from single-cell RNA-seq data. This package interfaces with Anndata objects to call CyteType API.
 
 ## Example Report

--- a/cytetype/__init__.py
+++ b/cytetype/__init__.py
@@ -1,4 +1,4 @@
 from .main import CyteType
 
 __all__ = ["CyteType"]
-__version__ = "0.5.2"
+__version__ = "0.6.0"

--- a/cytetype/config.py
+++ b/cytetype/config.py
@@ -11,6 +11,6 @@ logger.add(
 )
 
 
-DEFAULT_API_URL = "https://nygen-labs-prod--cell-annotation-agent-fastapi-app.modal.run"
+DEFAULT_API_URL = "https://nygen-labs-prod--cytetype-api.modal.run"
 DEFAULT_POLL_INTERVAL = 30
 DEFAULT_TIMEOUT = 3600

--- a/cytetype/main.py
+++ b/cytetype/main.py
@@ -3,6 +3,7 @@ import json
 
 import anndata
 import pandas as pd
+from natsort import natsorted
 from pydantic import BaseModel, Field, ConfigDict
 
 from .config import logger, DEFAULT_API_URL, DEFAULT_POLL_INTERVAL, DEFAULT_TIMEOUT
@@ -129,7 +130,7 @@ class CyteType:
 
         self.cluster_map = {
             str(x): str(n + 1)
-            for n, x in enumerate(sorted(adata.obs[group_key].unique().tolist()))
+            for n, x in enumerate(natsorted(adata.obs[group_key].unique().tolist()))
         }
         self.clusters = [
             self.cluster_map[str(x)] for x in adata.obs[group_key].values.tolist()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,13 @@ description = "Python client for characterization of clusters from single-cell R
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "anndata>=0.11.4",
-    "loguru>=0.7.3",
-    "requests>=2.32.3",
-    "pydantic>=2.0.0",
-    "session-info>=1.0.1",
-    "python-dotenv>=1.1.0",
+    "anndata~=0.11.4",
+    "loguru~=0.7.3",
+    "natsort~=8.4.0",
+    "requests~=2.32.3",
+    "pydantic~=2.11.7",
+    "session-info~=1.0.1",
+    "python-dotenv~=1.1.1",
 ]
 authors = [
     {name = "Parashar Dhapola", email = "parashar@nygen.io"}

--- a/uv.lock
+++ b/uv.lock
@@ -369,6 +369,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anndata" },
     { name = "loguru" },
+    { name = "natsort" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "requests" },
@@ -387,12 +388,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anndata", specifier = ">=0.11.4" },
-    { name = "loguru", specifier = ">=0.7.3" },
-    { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "python-dotenv", specifier = ">=1.1.0" },
-    { name = "requests", specifier = ">=2.32.3" },
-    { name = "session-info", specifier = ">=1.0.1" },
+    { name = "anndata", specifier = "~=0.11.4" },
+    { name = "loguru", specifier = "~=0.7.3" },
+    { name = "natsort", specifier = "~=8.4.0" },
+    { name = "pydantic", specifier = "~=2.11.7" },
+    { name = "python-dotenv", specifier = "~=1.1.1" },
+    { name = "requests", specifier = "~=2.32.3" },
+    { name = "session-info", specifier = "~=1.0.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -1575,7 +1577,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.5"
+version = "2.11.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -1583,9 +1585,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/86/8ce9040065e8f924d642c58e4a344e33163a07f6b57f836d0d734e0ad3fb/pydantic-2.11.5.tar.gz", hash = "sha256:7f853db3d0ce78ce8bbb148c401c2cdd6431b3473c0cdff2755c7690952a7b7a", size = 787102, upload-time = "2025-05-22T21:18:08.761Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/dd/4325abf92c39ba8623b5af936ddb36ffcfe0beae70405d456ab1fb2f5b8c/pydantic-2.11.7.tar.gz", hash = "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db", size = 788350, upload-time = "2025-06-14T08:33:17.137Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/69/831ed22b38ff9b4b64b66569f0e5b7b97cf3638346eb95a2147fdb49ad5f/pydantic-2.11.5-py3-none-any.whl", hash = "sha256:f9c26ba06f9747749ca1e5c94d6a85cb84254577553c8785576fd38fa64dc0f7", size = 444229, upload-time = "2025-05-22T21:18:06.329Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b", size = 444782, upload-time = "2025-06-14T08:33:14.905Z" },
 ]
 
 [[package]]
@@ -1716,11 +1718,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload-time = "2025-03-25T10:14:56.835Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload-time = "2025-03-25T10:14:55.034Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updated the CyteType API URL in both the README and config.py to reflect the new endpoint. Added natsort as a dependency and used it for natural sorting of cluster labels in main.py. Updated dependencies in pyproject.toml to use compatible version specifiers and bumped the package version to 0.6.0.