### PR TITLE
Marker gene validation

### DIFF
--- a/cytetype/preprocessing/extraction.py
+++ b/cytetype/preprocessing/extraction.py
@@ -78,10 +78,18 @@ def extract_marker_genes(
             gene_ids_to_name[gene] for gene in top_genes if gene in gene_ids_to_name
         ]
 
-    if not any_genes_found:
+        lost_genes = len(top_genes) - len(markers[cluster_id])
+        if lost_genes > 0:
+            logger.warning(
+                f"Number of lost genes ({lost_genes}) for group '{group_name}' (cluster '{cluster_id}'). \n"
+                f"This could indicate inconsistencies with the marker genes and the genes in adata.var."
+            )
+
+    if not any(markers.values()):
         raise ValueError(
-            "No marker genes found for any group. This could indicate issues with the "
-            "rank_genes_groups analysis or that all groups have insufficient marker genes."
+            "All marker gene lists are empty. Gene names in rank_genes_groups "
+            "could not be matched to adata.var_names. This typically happens "
+            "when var_names were changed after rank_genes_groups was run."
         )
 
     return markers

--- a/cytetype/preprocessing/extraction.py
+++ b/cytetype/preprocessing/extraction.py
@@ -95,6 +95,7 @@ def extract_marker_genes(
         raise ValueError(
             "No marker genes found for any group. This could indicate issues with the "
             "rank_genes_groups analysis or that all groups have insufficient marker genes."
+        )
 
     return markers
 

--- a/cytetype/preprocessing/extraction.py
+++ b/cytetype/preprocessing/extraction.py
@@ -85,16 +85,17 @@ def extract_marker_genes(
                 f"This could indicate inconsistencies with the marker genes and the genes in adata.var."
             )
 
+    if not any_genes_found:
+        raise ValueError(
+            "No marker genes found for any group. This could indicate issues with the "
+            "rank_genes_groups analysis or that all groups have insufficient marker genes."
+        )
+
     if not any(markers.values()):
         raise ValueError(
             "All marker gene lists are empty. Gene names in rank_genes_groups "
             "could not be matched to adata.var_names. This typically happens "
             "when var_names were changed after rank_genes_groups was run."
-        )
-    if not any_genes_found:
-        raise ValueError(
-            "No marker genes found for any group. This could indicate issues with the "
-            "rank_genes_groups analysis or that all groups have insufficient marker genes."
         )
 
     return markers

--- a/cytetype/preprocessing/extraction.py
+++ b/cytetype/preprocessing/extraction.py
@@ -91,6 +91,10 @@ def extract_marker_genes(
             "could not be matched to adata.var_names. This typically happens "
             "when var_names were changed after rank_genes_groups was run."
         )
+    if not any_genes_found:
+        raise ValueError(
+            "No marker genes found for any group. This could indicate issues with the "
+            "rank_genes_groups analysis or that all groups have insufficient marker genes."
 
     return markers
 

--- a/cytetype/preprocessing/validation.py
+++ b/cytetype/preprocessing/validation.py
@@ -338,6 +338,28 @@ def validate_adata(
             f"'names' field in `adata.uns['{rank_genes_key}']` is missing or invalid."
         )
 
+    rank_names = adata.uns[rank_genes_key]["names"]
+    try:
+        sample_genes = [
+            str(g)
+            for field in rank_names.dtype.names[:3]
+            for g in rank_names[field][:20]
+        ]
+    except Exception:
+        sample_genes = []
+
+    if sample_genes:
+        id_pct = _id_like_percentage(sample_genes)
+        if id_pct > 50:
+            examples = [g for g in sample_genes if _is_gene_id_like(g)][:3]
+            logger.warning(
+                f"rank_genes_groups results contain gene IDs rather than gene symbols "
+                f"(e.g. {examples}). This typically happens when var_names were Ensembl "
+                f"IDs at the time rank_genes_groups was run but have since been replaced "
+                f"with gene symbols. Marker gene extraction may fail or produce empty "
+                f"results. Consider re-running sc.tl.rank_genes_groups on the current adata."
+            )
+
     # Validate coordinates with fallback options (case-insensitive matching)
     common_coordinate_keys = [coordinates_key, "X_umap", "X_tsne", "X_pca"]
     found_coordinates_key: str | None = None

--- a/cytetype/preprocessing/validation.py
+++ b/cytetype/preprocessing/validation.py
@@ -338,28 +338,6 @@ def validate_adata(
             f"'names' field in `adata.uns['{rank_genes_key}']` is missing or invalid."
         )
 
-    rank_names = adata.uns[rank_genes_key]["names"]
-    try:
-        sample_genes = [
-            str(g)
-            for field in rank_names.dtype.names[:3]
-            for g in rank_names[field][:20]
-        ]
-    except Exception:
-        sample_genes = []
-
-    if sample_genes:
-        id_pct = _id_like_percentage(sample_genes)
-        if id_pct > 50:
-            examples = [g for g in sample_genes if _is_gene_id_like(g)][:3]
-            logger.warning(
-                f"rank_genes_groups results contain gene IDs rather than gene symbols "
-                f"(e.g. {examples}). This typically happens when var_names were Ensembl "
-                f"IDs at the time rank_genes_groups was run but have since been replaced "
-                f"with gene symbols. Marker gene extraction may fail or produce empty "
-                f"results. Consider re-running sc.tl.rank_genes_groups on the current adata."
-            )
-
     # Validate coordinates with fallback options (case-insensitive matching)
     common_coordinate_keys = [coordinates_key, "X_umap", "X_tsne", "X_pca"]
     found_coordinates_key: str | None = None


### PR DESCRIPTION
Implement simple checks on the marker genes before payload construction:

- Check for gene id to gene symbols mapping errors, warning for genes lost in mapping
- Raise value error if marker genes are empty, prevent sending empty marker gene lists
- Validation check if marker genes from adata.uns are gene id like
